### PR TITLE
SetupWizard: Update Location services page

### DIFF
--- a/res/layout/location_settings.xml
+++ b/res/layout/location_settings.xml
@@ -118,7 +118,7 @@
                 </LinearLayout>
 
                 <LinearLayout
-                    android:id="@+id/gps"
+                    android:id="@+id/battery_saving"
                     android:orientation="horizontal"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -128,7 +128,7 @@
                     android:clickable="true">
 
                     <CheckBox
-                        android:id="@+id/gps_checkbox"
+                        android:id="@+id/battery_saving_checkbox"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="top"
@@ -138,7 +138,7 @@
 
 
                     <TextView
-                        android:id="@+id/gps_summary"
+                        android:id="@+id/battery_saving_summary"
                         android:layout_width="0px"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
@@ -148,7 +148,7 @@
                         android:layout_marginLeft="@dimen/location_text_margin_left"
                         android:layout_marginRight="@dimen/location_text_margin_right"
                         android:paddingBottom="@dimen/content_margin_bottom"
-                        android:text="@string/location_gps"
+                        android:text="@string/location_battery_saving"
                         android:maxLines="5" />
 
                 </LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -51,8 +51,7 @@
     <string name="other_services_summary">These services put Google to work for you, and you can turn them on or off at any time. Data will be used in accordance with Google\'s <xliff:g id="name" example="Privacy Policy">%s</xliff:g>.</string>
     <string name="location_services_summary">Location services allows system and third party apps to gather and use data such as your approximate location. For example, an app may use your approximate location to locate nearby coffee shops.</string>
     <string name="location_access_summary"><b>Allow apps that have asked your permission</b> to use your location information. This may include your current location and past locations.</string>
-    <string name="location_gps" product="tablet"><b>Improve location accuracy</b> by allowing apps to use the GPS on your tablet.</string>
-    <string name="location_gps" product="default"><b>Improve location accuracy</b> by allowing apps to use the GPS on your phone.</string>
+    <string name="location_battery_saving"><b>Reduce battery consumption</b> by restricting the number of GPS updates per hour.</string>
     <string name="location_network"><b>Use Wi-Fi</b> to help apps determine your location.</string>
     <string name="location_network_telephony"><b>Use Wi-Fi and mobile networks</b> to help apps determine your location.</string>
     <string name="location_network_gms"><b>Use Google\'s location service</b> to help apps determine your location. This means sending anonymous location data to Google, even when no apps are running.</string>


### PR DESCRIPTION
- Remove usage of deprecated setLocationProviderEnabled and
  isLocationProviderEnabled
- Use BroadcastReceiver to listen for changes to mode
- Replace GPS option with Battery Saving option (there is no longer a
  mode available in Android which disables GPS)

TODO: Create CMStats entry for ENABLE_BATTERY_SAVING_LOCATION

Change-Id: I2efe69125518637ae9b7d0dce285c39dae654d4c
