### PR TITLE
SetupWizard : Set min date to Jan 1, 2016 GMT

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/DateTimePage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/DateTimePage.java
@@ -188,6 +188,18 @@ public class DateTimePage extends SetupPage {
                     });
                 }
             });
+            // Pre-select current/default date if epoch
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    final Calendar calendar = Calendar.getInstance();
+                    final boolean isEpoch = calendar.get(Calendar.YEAR) == 1970;
+                    if (isEpoch) {
+                        // If epoch, set date to a default date
+                        setDate(getActivity(), 2016, Calendar.JANUARY, 1);
+                    }
+                }
+            });
         }
 
         private void showDatePicker() {


### PR DESCRIPTION
In the event that the current time returns us epoch,
hard code the time so the user doesn't have to
scroll all the way to 2016 when setting the time.

CRACKLING-721

Change-Id: I7a4122320c80e941154b84f306565c0f9b452a7d
