### PR TITLE
SetupWizard : Use MccTable for mcc -> locale lookup

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -16,7 +16,8 @@ LOCAL_STATIC_JAVA_LIBRARIES := \
     android-support-v13 \
     play \
     libphonenumber \
-    org.cyanogenmod.platform.sdk
+    org.cyanogenmod.platform.sdk \
+    telephony-common
 
 # Include res dir from chips
 google_play_dir := ../../../external/google/google_play_services/libproject/google-play-services_lib/res

--- a/src/com/cyanogenmod/setupwizard/setup/WelcomePage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/WelcomePage.java
@@ -30,6 +30,8 @@ import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
+import android.telephony.SubscriptionInfo;
+import android.telephony.SubscriptionManager;
 import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.view.View;
@@ -37,6 +39,7 @@ import android.widget.ArrayAdapter;
 import android.widget.NumberPicker;
 import android.widget.Toast;
 
+import com.android.internal.telephony.MccTable;
 import com.cyanogenmod.setupwizard.R;
 import com.cyanogenmod.setupwizard.SetupWizardApp;
 import com.cyanogenmod.setupwizard.cmstats.SetupStats;
@@ -44,6 +47,7 @@ import com.cyanogenmod.setupwizard.ui.LocalePicker;
 import com.cyanogenmod.setupwizard.ui.SetupPageFragment;
 import com.cyanogenmod.setupwizard.util.SetupWizardUtils;
 
+import java.util.List;
 import java.util.Locale;
 
 public class WelcomePage extends SetupPage {
@@ -285,16 +289,34 @@ public class WelcomePage extends SetupPage {
         private class FetchUpdateSimLocaleTask extends AsyncTask<Void, Void, Locale> {
             @Override
             protected Locale doInBackground(Void... params) {
+                Locale locale = null;
                 Activity activity = getActivity();
                 if (activity != null) {
-                    TelephonyManager telephonyManager = (TelephonyManager) activity.
-                            getSystemService(Context.TELEPHONY_SERVICE);
-                    String locale = telephonyManager.getLocaleFromDefaultSim();
-                    if (locale != null) {
-                        return Locale.forLanguageTag(locale);
+                    final SubscriptionManager subscriptionManager =
+                            SubscriptionManager.from(activity);
+                    List<SubscriptionInfo> activeSubs =
+                            subscriptionManager.getActiveSubscriptionInfoList();
+                    if (activeSubs == null || activeSubs.isEmpty()) {
+                        return null;
+                    }
+
+                    // Fetch locale for active sim's MCC
+                    int mcc = activeSubs.get(0).getMcc();
+                    locale = MccTable.getLocaleFromMcc(activity, mcc, null);
+
+                    // If that fails, fall back to preferred languages reported
+                    // by the sim
+                    if (locale == null) {
+                        TelephonyManager telephonyManager = (TelephonyManager) activity.
+                                getSystemService(Context.TELEPHONY_SERVICE);
+                        String localeString = telephonyManager.getLocaleFromDefaultSim();
+                        if (localeString != null) {
+                            locale = Locale.forLanguageTag(localeString);
+
+                        }
                     }
                 }
-                return null;
+                return locale;
             }
 
             @Override


### PR DESCRIPTION
Some sims such as T-Mobile return incorrect languages for their
PL(Preferred languages). Lookup the locale via the MccTable instead,
and fallback to trusting the sim.

Change-Id: I612d4952355ce4a42b35579e1f9aa879417c4cd4
